### PR TITLE
Add support for structured outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,55 @@ final response = await aiEngine.generateText(
 print(response.text);
 ```
 
+### Structured Outputs (Apple platforms)
+
+Pass a JSON Schema through `GenerationConfig` to *constrain* generation to valid
+JSON instead of free-form text. On Apple FoundationModels this uses the same
+schema-constrained generation that powers tool calling, so the model is forced to
+emit a value matching your schema.
+
+- **iOS 26.0+ / macOS 26.0+**: native. The schema is translated into a
+  FoundationModels `GenerationSchema` and the JSON is returned in
+  `AiResponse.text`; use `AiResponse.json` to get it decoded as a `Map`.
+- **Android / Windows**: not supported — these backends are text-out only.
+  Supplying a `schema` (or `responseFormat: ResponseFormat.json`) throws a
+  `STRUCTURED_OUTPUT_UNSUPPORTED` error. Gate on
+  `getPlatformInfo().supportsStructuredOutput` in cross-platform code.
+
+Supported schema constructs: objects (with `required`), arrays, string enums, and
+the scalar types (`string`, `integer`, `number`, `boolean`). `description` is
+honored on properties.
+
+```dart
+final response = await aiEngine.generateText(
+  prompt: 'Summarize this support ticket: "App crashes on launch after update."',
+  config: const GenerationConfig(
+    maxTokens: 300,
+    responseFormat: ResponseFormat.json, // default is ResponseFormat.text
+    schema: {
+      'type': 'object',
+      'properties': {
+        'title': {'type': 'string', 'description': 'Short headline'},
+        'priority': {
+          'enum': ['low', 'med', 'high'],
+        },
+        'tags': {
+          'type': 'array',
+          'items': {'type': 'string'},
+        },
+      },
+      'required': ['title'],
+    },
+  ),
+);
+
+final data = response.json; // Map<String, dynamic>? — decoded JSON
+print(data?['title']);
+```
+
+> Note: `ResponseFormat.json` requires a non-null `schema` — Apple can only
+> constrain output when given a schema to constrain it to.
+
 ### Generative UI (genUI)
 
 `flutter_local_ai` can turn a natural-language goal into a small, renderable UI
@@ -788,7 +837,7 @@ Main class for interacting with local AI.
 - `Stream<String> generateTextStream({required String prompt, GenerationConfig? config, String? instructions})` - Generate text as a stream of delta chunks
 - `Future<String> generateTextSimple({required String prompt, int maxTokens = 100})` - Convenience method to generate text and return just the string
 - `Future<void> registerTools(List<LocalAiTool> tools)` - Register Dart tools the model may call during generation (Apple platforms only; pass `const []` to clear)
-- `Future<LocalAiPlatformInfo> getPlatformInfo()` - The detected backend and its capabilities (`supportsToolCalling`, `supportsModelDownload`, …)
+- `Future<LocalAiPlatformInfo> getPlatformInfo()` - The detected backend and its capabilities (`supportsToolCalling`, `supportsStructuredOutput`, `supportsModelDownload`, …)
 - `Future<ModelFeatureStatus> getModelStatus()` - `available` / `downloadable` / `downloading` / `unavailable` (Android Gemini Nano)
 - `Stream<ModelDownloadStatus> downloadModel()` - Request the one-time on-device model download and observe its progress; failures always surface on the stream
 - `Future<bool> openAICorePlayStore()` - Open Google AICore in the Play Store (Android only, useful when error -101 occurs)
@@ -806,14 +855,20 @@ Configuration for text generation.
 
 - `maxTokens` (int, default: 100) - Maximum number of tokens to generate
 - `temperature` (double?, optional) - Temperature for generation (0.0 to 1.0)
-- `topP` (double?, optional) - Top-p sampling parameter
-- `topK` (int?, optional) - Top-k sampling parameter
+- `topP` (double?, optional) - Top-p (nucleus) sampling. On Apple maps to `.random(probabilityThreshold:)`
+- `topK` (int?, optional) - Top-k sampling. On Apple maps to `.random(top:)` and takes precedence over `topP`
+- `responseFormat` (`ResponseFormat`, default: `text`) - `text` for free-form output, or `json` for schema-constrained JSON (Apple only). `json` requires a non-null `schema`
+- `schema` (`Map<String, dynamic>?`, optional) - JSON Schema the output is constrained to (Apple only; see Structured Outputs above)
+
+> Sampling precedence on Apple: topK > topP > temperature > greedy. `.greedy` is
+> never combined with a temperature (that pairing throws on-device).
 
 ### `AiResponse`
 
 Response from AI generation.
 
-- `text` (String) - The generated text
+- `text` (String) - The generated text (or the JSON string when structured output was requested)
+- `json` (`Map<String, dynamic>?`) - `text` decoded as a JSON object, or `null` if it isn't one
 - `tokenCount` (int?) - Token count used
 - `generationTimeMs` (int?) - Generation time in milliseconds
 

--- a/android/src/main/kotlin/io/vezz/flutter_local_ai/FlutterLocalAiPlugin.kt
+++ b/android/src/main/kotlin/io/vezz/flutter_local_ai/FlutterLocalAiPlugin.kt
@@ -76,6 +76,15 @@ class FlutterLocalAiPlugin: FlutterPlugin, MethodCallHandler {
           result.error("INVALID_ARGUMENT", "Prompt is required", null)
           return
         }
+        if (requestsStructuredOutput(configMap)) {
+          result.error(
+            "STRUCTURED_OUTPUT_UNSUPPORTED",
+            "Schema-constrained (JSON) output is not supported on Android: the " +
+              "ML Kit GenAI Prompt API is text-in/text-out only.",
+            null
+          )
+          return
+        }
 
         coroutineScope.launch {
           try {
@@ -93,6 +102,15 @@ class FlutterLocalAiPlugin: FlutterPlugin, MethodCallHandler {
         val oneShot = call.argument<String>("instructions")
         if (prompt == null || requestId == null) {
           result.error("INVALID_ARGUMENT", "Prompt and request id are required", null)
+          return
+        }
+        if (requestsStructuredOutput(configMap)) {
+          result.error(
+            "STRUCTURED_OUTPUT_UNSUPPORTED",
+            "Schema-constrained (JSON) output is not supported on Android: the " +
+              "ML Kit GenAI Prompt API is text-in/text-out only.",
+            null
+          )
           return
         }
 
@@ -183,8 +201,17 @@ class FlutterLocalAiPlugin: FlutterPlugin, MethodCallHandler {
       "supportsToolCalling" to false,
       "supportsModelDownload" to true,
       "supportsPlayStoreRedirect" to true,
+      // The Prompt API can't constrain output to a schema (text-in/text-out).
+      "supportsStructuredOutput" to false,
       "isConfigured" to true
     )
+  }
+
+  /// Whether the supplied generation config asks for schema-constrained JSON
+  /// output, which Android's text-only Prompt API can't honor.
+  private fun requestsStructuredOutput(configMap: Map<String, Any>?): Boolean {
+    if (configMap == null) return false
+    return configMap["schema"] != null || configMap["responseFormat"] == "json"
   }
 
   private suspend fun checkAvailability(): Boolean = withContext(Dispatchers.IO) {

--- a/darwin/flutter_local_ai/Classes/FlutterLocalAiPlugin.swift
+++ b/darwin/flutter_local_ai/Classes/FlutterLocalAiPlugin.swift
@@ -119,31 +119,74 @@ import FoundationModels
       return session
     }
 
+    /// Builds `GenerationOptions` from the requested sampling knobs.
+    ///
+    /// Sampling modes are mutually exclusive, and `.greedy` must NOT be combined
+    /// with a temperature (that pairing throws a GenerationError on-device).
+    /// Precedence: topK > topP > temperature > greedy. When a top-k/top-p mode
+    /// is chosen, a positive temperature is allowed to ride alongside it.
+    static func makeOptions(
+      maxTokens: Int,
+      temperature: Double?,
+      topP: Double?,
+      topK: Int?
+    ) -> GenerationOptions {
+      let positiveTemp = (temperature ?? 0) > 0 ? temperature : nil
+      if let topK = topK {
+        return GenerationOptions(
+          sampling: .random(top: topK),
+          temperature: positiveTemp,
+          maximumResponseTokens: maxTokens
+        )
+      }
+      if let topP = topP {
+        return GenerationOptions(
+          sampling: .random(probabilityThreshold: topP),
+          temperature: positiveTemp,
+          maximumResponseTokens: maxTokens
+        )
+      }
+      if let temp = positiveTemp {
+        return GenerationOptions(temperature: temp, maximumResponseTokens: maxTokens)
+      }
+      return GenerationOptions(sampling: .greedy, maximumResponseTokens: maxTokens)
+    }
+
     func generateText(
       prompt: String,
       maxTokens: Int,
       temperature: Double?,
+      topP: Double? = nil,
+      topK: Int? = nil,
+      schema: [String: Any]? = nil,
       instructions oneShot: String? = nil
     ) async throws -> [String: Any] {
       let startTime = Date()
       let session = try await sessionFor(oneShot: oneShot)
 
-      // Build generation options. NOTE: `.greedy` sampling must NOT be combined
-      // with a temperature (they are mutually exclusive and trigger a
-      // GenerationError on-device). Pick one based on the requested temp.
-      let options: GenerationOptions
-      if let temp = temperature, temp > 0 {
-        options = GenerationOptions(temperature: temp, maximumResponseTokens: maxTokens)
-      } else {
-        options = GenerationOptions(sampling: .greedy, maximumResponseTokens: maxTokens)
-      }
+      let options = ModelManager.makeOptions(
+        maxTokens: maxTokens,
+        temperature: temperature,
+        topP: topP,
+        topK: topK
+      )
 
       // Generate text. On any failure, surface a fully-reflected description so
       // the concrete error case (guardrail, missing assets, etc.) is diagnosable.
+      // When a schema is supplied, generation is constrained to it and the
+      // resulting JSON is returned as the text payload.
       let generatedText: String
       do {
-        let response = try await session.respond(to: prompt, options: options)
-        generatedText = response.content
+        if let schema = schema {
+          let generationSchema = try SchemaBuilder.generationSchema(
+            from: schema, rootName: "Output")
+          let response = try await session.respond(
+            to: prompt, schema: generationSchema, options: options)
+          generatedText = response.content.jsonString
+        } else {
+          let response = try await session.respond(to: prompt, options: options)
+          generatedText = response.content
+        }
       } catch {
         throw NSError(
           domain: "FlutterLocalAiPlugin",
@@ -174,19 +217,19 @@ import FoundationModels
       prompt: String,
       maxTokens: Int,
       temperature: Double?,
+      topP: Double? = nil,
+      topK: Int? = nil,
       instructions oneShot: String? = nil,
       onDelta: @Sendable @escaping (String) -> Void
     ) async throws {
       let session = try await sessionFor(oneShot: oneShot)
 
-      // Same mutual exclusion as generateText: `.greedy` sampling must not be
-      // combined with a temperature.
-      let options: GenerationOptions
-      if let temp = temperature, temp > 0 {
-        options = GenerationOptions(temperature: temp, maximumResponseTokens: maxTokens)
-      } else {
-        options = GenerationOptions(sampling: .greedy, maximumResponseTokens: maxTokens)
-      }
+      let options = ModelManager.makeOptions(
+        maxTokens: maxTokens,
+        temperature: temperature,
+        topP: topP,
+        topK: topK
+      )
 
       do {
         let stream = session.streamResponse(to: prompt, options: options)
@@ -281,6 +324,7 @@ import FoundationModels
       "supportsToolCalling": supportsFoundationModels,
       "supportsModelDownload": false,
       "supportsPlayStoreRedirect": false,
+      "supportsStructuredOutput": supportsFoundationModels,
       "isConfigured": configured
     ])
   }
@@ -449,6 +493,9 @@ import FoundationModels
       let configMap = args["config"] as? [String: Any]
       let maxTokens = configMap?["maxTokens"] as? Int ?? 100
       let temperature = configMap?["temperature"] as? Double
+      let topP = configMap?["topP"] as? Double
+      let topK = configMap?["topK"] as? Int
+      let schema = configMap?["schema"] as? [String: Any]
       let oneShot = args["instructions"] as? String
 
       Task {
@@ -457,6 +504,9 @@ import FoundationModels
             prompt: prompt,
             maxTokens: maxTokens,
             temperature: temperature,
+            topP: topP,
+            topK: topK,
+            schema: schema,
             instructions: oneShot
           )
           result(response)
@@ -510,6 +560,8 @@ import FoundationModels
       let configMap = args["config"] as? [String: Any]
       let maxTokens = configMap?["maxTokens"] as? Int ?? 100
       let temperature = configMap?["temperature"] as? Double
+      let topP = configMap?["topP"] as? Double
+      let topK = configMap?["topK"] as? Int
       let oneShot = args["instructions"] as? String
 
       // The method call returns immediately; output is delivered through the
@@ -522,6 +574,8 @@ import FoundationModels
             prompt: prompt,
             maxTokens: maxTokens,
             temperature: temperature,
+            topP: topP,
+            topK: topK,
             instructions: oneShot
           ) { delta in
             DispatchQueue.main.async {
@@ -783,6 +837,95 @@ private enum FlutterToolParsingError: Error, LocalizedError {
       return "Unsupported parameter type '\(type)'."
     case .serializationFailed(let message):
       return message
+    }
+  }
+}
+
+/// Translates a raw JSON Schema map (as supplied through `GenerationConfig`) into
+/// a FoundationModels `GenerationSchema`, so generation can be constrained to it.
+///
+/// This is the structured-output counterpart of `FlutterTool.buildSchema`, but
+/// recursive: it supports nested objects, arrays, and string enums in addition to
+/// the scalar types tool parameters allow. Tree-shaped schemas nest inline via
+/// `Property.schema`, so the root needs no separate `dependencies`.
+@available(iOS 26.0, macOS 26.0, *)
+private enum SchemaBuilder {
+  static func generationSchema(
+    from json: [String: Any],
+    rootName: String
+  ) throws -> GenerationSchema {
+    let root = try node(from: json, name: rootName)
+    return try GenerationSchema(root: root, dependencies: [])
+  }
+
+  private static func node(
+    from json: [String: Any],
+    name: String
+  ) throws -> DynamicGenerationSchema {
+    let description = json["description"] as? String
+
+    // `enum` may appear with or without an explicit `type` in JSON Schema; treat
+    // it as a string-choice constraint regardless.
+    if let choices = json["enum"] as? [Any] {
+      let strings = choices.compactMap { $0 as? String }
+      guard strings.count == choices.count, !strings.isEmpty else {
+        throw SchemaError.unsupported(
+          "Only non-empty string enum values are supported (at `\(name)`).")
+      }
+      return DynamicGenerationSchema(name: name, description: description, anyOf: strings)
+    }
+
+    let type = (json["type"] as? String)?.lowercased() ?? "object"
+    switch type {
+    case "object":
+      let properties = json["properties"] as? [String: Any] ?? [:]
+      let required = Set(
+        (json["required"] as? [Any])?.compactMap { $0 as? String } ?? [])
+      let props: [DynamicGenerationSchema.Property] = try properties.map { key, value in
+        guard let child = value as? [String: Any] else {
+          throw SchemaError.unsupported("Property `\(key)` must be an object schema.")
+        }
+        return DynamicGenerationSchema.Property(
+          name: key,
+          description: child["description"] as? String,
+          schema: try node(from: child, name: "\(name)_\(key)"),
+          isOptional: !required.contains(key)
+        )
+      }
+      return DynamicGenerationSchema(
+        name: name, description: description, properties: props)
+
+    case "array":
+      guard let items = json["items"] as? [String: Any] else {
+        throw SchemaError.unsupported("Array `\(name)` requires an `items` schema.")
+      }
+      return DynamicGenerationSchema(
+        arrayOf: try node(from: items, name: "\(name)_item"),
+        minimumElements: json["minItems"] as? Int,
+        maximumElements: json["maxItems"] as? Int
+      )
+
+    case "string":
+      return DynamicGenerationSchema(type: String.self)
+    case "integer":
+      return DynamicGenerationSchema(type: Int.self)
+    case "number":
+      return DynamicGenerationSchema(type: Double.self)
+    case "boolean":
+      return DynamicGenerationSchema(type: Bool.self)
+    default:
+      throw SchemaError.unsupported("Unsupported schema type `\(type)` at `\(name)`.")
+    }
+  }
+
+  enum SchemaError: Error, LocalizedError {
+    case unsupported(String)
+
+    var errorDescription: String? {
+      switch self {
+      case .unsupported(let message):
+        return message
+      }
     }
   }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,0 +1,43 @@
+PODS:
+  - audioplayers_darwin (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - Flutter (1.0.0)
+  - flutter_local_ai (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
+  - video_player_avfoundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - audioplayers_darwin (from `.symlinks/plugins/audioplayers_darwin/darwin`)
+  - Flutter (from `Flutter`)
+  - flutter_local_ai (from `.symlinks/plugins/flutter_local_ai/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
+  - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
+
+EXTERNAL SOURCES:
+  audioplayers_darwin:
+    :path: ".symlinks/plugins/audioplayers_darwin/darwin"
+  Flutter:
+    :path: Flutter
+  flutter_local_ai:
+    :path: ".symlinks/plugins/flutter_local_ai/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
+  video_player_avfoundation:
+    :path: ".symlinks/plugins/video_player_avfoundation/darwin"
+
+SPEC CHECKSUMS:
+  audioplayers_darwin: f15e209a3e856d1a7edcf98dc029f484fead2242
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_local_ai: f75692258153d225d3dbc173bdf093fad8f19d63
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  video_player_avfoundation: e54d03b3b19f64f2c557354f72ce538387541ba6
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.16.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				C1D9057887A18C1D7A15220C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -330,6 +331,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		C1D9057887A18C1D7A15220C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		DB98AAA3D26DAAF89D8EE08C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -371,10 +371,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -560,10 +560,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/genui/genui_module_spec.dart
+++ b/lib/src/genui/genui_module_spec.dart
@@ -26,8 +26,18 @@ class GenUiModuleSpec {
   });
 
   static const _allowedBlocks = {
-    'note', 'field', 'amount', 'progress', 'checklist', 'week', 'stat', 'list',
-    'lessons', 'reminder', 'calc', 'docs',
+    'note',
+    'field',
+    'amount',
+    'progress',
+    'checklist',
+    'week',
+    'stat',
+    'list',
+    'lessons',
+    'reminder',
+    'calc',
+    'docs',
   };
   static const _allowedTones = {'fern', 'apricot', 'sky', 'lilac'};
 
@@ -80,7 +90,9 @@ class GenUiModuleSpec {
   List<Component> toComponents() {
     final children = <String>['gen_header'];
     final components = <Component>[
-      Component(id: 'gen_header', type: 'Text',
+      Component(
+          id: 'gen_header',
+          type: 'Text',
           properties: {'text': title, 'variant': 'h4'}),
     ];
 
@@ -88,12 +100,14 @@ class GenUiModuleSpec {
       final b = blocks[i];
       final id = 'gen_block_$i';
       children.add(id);
-      components.add(Component(id: id, type: 'Text',
-          properties: {'text': _describeBlock(b)}));
+      components.add(Component(
+          id: id, type: 'Text', properties: {'text': _describeBlock(b)}));
     }
 
     components.insert(
-        0, Component(id: 'root', type: 'Column', properties: {'children': children}));
+        0,
+        Component(
+            id: 'root', type: 'Column', properties: {'children': children}));
     return components;
   }
 

--- a/lib/src/genui/local_ai_ui_generator.dart
+++ b/lib/src/genui/local_ai_ui_generator.dart
@@ -194,7 +194,9 @@ Keep copy warm, plain and encouraging. Never use emoji.
       final buf = StringBuffer();
       try {
         await for (final chunk in _ai.generateTextStream(
-            prompt: prompt, config: config, instructions: _systemInstructions)) {
+            prompt: prompt,
+            config: config,
+            instructions: _systemInstructions)) {
           buf.write(chunk);
           onText(buf.toString());
         }

--- a/lib/src/models/ai_response.dart
+++ b/lib/src/models/ai_response.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// Response from AI generation
 class AiResponse {
   /// The generated text
@@ -14,6 +16,19 @@ class AiResponse {
     this.tokenCount,
     this.generationTimeMs,
   });
+
+  /// The generated text decoded as a JSON object, or `null` if [text] is not a
+  /// JSON object (e.g. free-form text, or malformed/truncated JSON). Use this
+  /// when generation was constrained by a schema via
+  /// `GenerationConfig(responseFormat: ResponseFormat.json, schema: ...)`.
+  Map<String, dynamic>? get json {
+    try {
+      final decoded = jsonDecode(text);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } on FormatException {
+      return null;
+    }
+  }
 
   factory AiResponse.fromMap(Map<String, dynamic> map) {
     return AiResponse(

--- a/lib/src/models/generation_config.dart
+++ b/lib/src/models/generation_config.dart
@@ -1,3 +1,14 @@
+/// Desired shape of the generated output.
+enum ResponseFormat {
+  /// Free-form text (the default).
+  text,
+
+  /// Schema-constrained JSON. Requires [GenerationConfig.schema] and is only
+  /// honored on backends that report `supportsStructuredOutput` (Apple
+  /// FoundationModels). Other backends throw when JSON output is requested.
+  json,
+}
+
 /// Configuration for text generation
 class GenerationConfig {
   /// Maximum number of tokens to generate
@@ -6,12 +17,44 @@ class GenerationConfig {
   /// Temperature for generation (0.0 to 1.0)
   final double? temperature;
 
-  const GenerationConfig({this.maxTokens = 100, this.temperature});
+  /// Nucleus sampling probability threshold (top-p). On Apple this selects the
+  /// `.random(probabilityThreshold:)` sampling mode.
+  final double? topP;
+
+  /// Top-K sampling parameter. On Apple this selects the `.random(top:)`
+  /// sampling mode and takes precedence over [topP].
+  final int? topK;
+
+  /// Desired output format. Defaults to [ResponseFormat.text]. Selecting
+  /// [ResponseFormat.json] requires a non-null [schema].
+  final ResponseFormat responseFormat;
+
+  /// JSON Schema describing the structured output. When provided (with
+  /// [responseFormat] == [ResponseFormat.json]), the model is constrained to
+  /// emit JSON matching this schema. Only supported on Apple FoundationModels;
+  /// see `LocalAiPlatformInfo.supportsStructuredOutput`.
+  final Map<String, dynamic>? schema;
+
+  const GenerationConfig({
+    this.maxTokens = 100,
+    this.temperature,
+    this.topP,
+    this.topK,
+    this.responseFormat = ResponseFormat.text,
+    this.schema,
+  }) : assert(
+          responseFormat == ResponseFormat.text || schema != null,
+          'ResponseFormat.json requires a non-null schema.',
+        );
 
   Map<String, dynamic> toMap() {
     return {
       'maxTokens': maxTokens,
       if (temperature != null) 'temperature': temperature,
+      if (topP != null) 'topP': topP,
+      if (topK != null) 'topK': topK,
+      'responseFormat': responseFormat.name,
+      if (schema != null) 'schema': schema,
     };
   }
 }

--- a/lib/src/models/model_status.dart
+++ b/lib/src/models/model_status.dart
@@ -51,7 +51,8 @@ class ModelDownloadStatus {
           totalBytesDownloaded: (map['totalBytesDownloaded'] as num?)?.toInt(),
         );
       case 'completed':
-        return const ModelDownloadStatus(type: ModelDownloadStatusType.completed);
+        return const ModelDownloadStatus(
+            type: ModelDownloadStatusType.completed);
       case 'failed':
         return ModelDownloadStatus(
           type: ModelDownloadStatusType.failed,

--- a/lib/src/models/platform_info.dart
+++ b/lib/src/models/platform_info.dart
@@ -30,6 +30,11 @@ class LocalAiPlatformInfo {
   final bool supportsPlayStoreRedirect;
   final bool isConfigured;
 
+  /// Whether the backend can constrain generation to a JSON schema
+  /// (`GenerationConfig.schema`). True only on Apple FoundationModels; other
+  /// backends throw when a schema is supplied.
+  final bool supportsStructuredOutput;
+
   const LocalAiPlatformInfo({
     required this.backend,
     required this.platform,
@@ -38,6 +43,7 @@ class LocalAiPlatformInfo {
     required this.supportsModelDownload,
     required this.supportsPlayStoreRedirect,
     required this.isConfigured,
+    this.supportsStructuredOutput = false,
   });
 
   factory LocalAiPlatformInfo.fromMap(Map<String, dynamic> map) {
@@ -50,6 +56,8 @@ class LocalAiPlatformInfo {
       supportsPlayStoreRedirect:
           map['supportsPlayStoreRedirect'] as bool? ?? false,
       isConfigured: map['isConfigured'] as bool? ?? false,
+      supportsStructuredOutput:
+          map['supportsStructuredOutput'] as bool? ?? false,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -364,10 +364,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -553,10 +553,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/test/flutter_local_ai_platform_interface_test.dart
+++ b/test/flutter_local_ai_platform_interface_test.dart
@@ -28,7 +28,9 @@ void main() {
 class ImplementsFlutterLocalAiPlatform implements FlutterLocalAiPlatform {
   @override
   Future<AiResponse> generateText(
-      {required String prompt, GenerationConfig? config, String? instructions}) {
+      {required String prompt,
+      GenerationConfig? config,
+      String? instructions}) {
     throw UnimplementedError();
   }
 
@@ -49,7 +51,9 @@ class ImplementsFlutterLocalAiPlatform implements FlutterLocalAiPlatform {
 
   @override
   Stream<String> generateTextStream(
-      {required String prompt, GenerationConfig? config, String? instructions}) {
+      {required String prompt,
+      GenerationConfig? config,
+      String? instructions}) {
     throw UnimplementedError();
   }
 

--- a/test/flutter_local_ai_test.dart
+++ b/test/flutter_local_ai_test.dart
@@ -121,6 +121,106 @@ void main() {
       expect(result, isTrue);
       expect(fakePlatform.openAICorePlayStoreCallCount, 1);
     });
+
+    test('structured-output config carries the schema to the platform',
+        () async {
+      fakePlatform.generateTextResult =
+          const AiResponse(text: '{"title":"Hello","priority":"high"}');
+
+      final config = GenerationConfig(
+        maxTokens: 128,
+        responseFormat: ResponseFormat.json,
+        schema: const {
+          'type': 'object',
+          'properties': {
+            'title': {'type': 'string'},
+            'priority': {
+              'enum': ['low', 'med', 'high'],
+            },
+          },
+          'required': ['title'],
+        },
+      );
+
+      final result = await subject.generateText(prompt: 'Hi', config: config);
+
+      expect(fakePlatform.lastConfig?.schema, isNotNull);
+      expect(fakePlatform.lastConfig?.responseFormat, ResponseFormat.json);
+      // The JSON arrives in `text`; `.json` is the decoded convenience view.
+      expect(result.json, {'title': 'Hello', 'priority': 'high'});
+    });
+  });
+
+  group('GenerationConfig', () {
+    test('toMap includes sampling knobs, response format, and schema', () {
+      const config = GenerationConfig(
+        maxTokens: 300,
+        temperature: 0.7,
+        topP: 0.9,
+        topK: 40,
+        responseFormat: ResponseFormat.json,
+        schema: {'type': 'object'},
+      );
+
+      expect(config.toMap(), {
+        'maxTokens': 300,
+        'temperature': 0.7,
+        'topP': 0.9,
+        'topK': 40,
+        'responseFormat': 'json',
+        'schema': {'type': 'object'},
+      });
+    });
+
+    test('toMap omits null knobs and defaults to text format', () {
+      const config = GenerationConfig(maxTokens: 100);
+
+      expect(config.toMap(), {
+        'maxTokens': 100,
+        'responseFormat': 'text',
+      });
+    });
+
+    test('JSON response format requires a schema', () {
+      expect(
+        () => GenerationConfig(responseFormat: ResponseFormat.json),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('AiResponse.json', () {
+    test('decodes a JSON object payload', () {
+      const response = AiResponse(text: '{"a":1,"b":"two"}');
+      expect(response.json, {'a': 1, 'b': 'two'});
+    });
+
+    test('returns null for free-form text', () {
+      const response = AiResponse(text: 'just words');
+      expect(response.json, isNull);
+    });
+
+    test('returns null for non-object JSON (e.g. an array)', () {
+      const response = AiResponse(text: '[1, 2, 3]');
+      expect(response.json, isNull);
+    });
+  });
+
+  group('LocalAiPlatformInfo', () {
+    test('fromMap round-trips supportsStructuredOutput', () {
+      final info = LocalAiPlatformInfo.fromMap(const {
+        'backend': 'apple_foundation_models',
+        'supportsStructuredOutput': true,
+      });
+      expect(info.supportsStructuredOutput, isTrue);
+    });
+
+    test('supportsStructuredOutput defaults to false when absent', () {
+      final info = LocalAiPlatformInfo.fromMap(const {
+        'backend': 'android_mlkit_genai',
+      });
+      expect(info.supportsStructuredOutput, isFalse);
+    });
   });
 }
 

--- a/windows/flutter_local_ai_plugin.cpp
+++ b/windows/flutter_local_ai_plugin.cpp
@@ -139,6 +139,8 @@ void FlutterLocalAiPlugin::GetPlatformInfo(
   response[EncodableValue("supportsToolCalling")] = EncodableValue(false);
   response[EncodableValue("supportsModelDownload")] = EncodableValue(false);
   response[EncodableValue("supportsPlayStoreRedirect")] = EncodableValue(false);
+  // Windows AI generation is text-out; it can't constrain output to a schema.
+  response[EncodableValue("supportsStructuredOutput")] = EncodableValue(false);
 #if WINDOWS_AI_AVAILABLE
   response[EncodableValue("backend")] = EncodableValue("windows_ai_foundry");
   response[EncodableValue("apiName")] = EncodableValue("Windows AI Foundry");
@@ -251,7 +253,28 @@ void FlutterLocalAiPlugin::GenerateText(
       return;
     }
     std::string prompt = *prompt_ptr;
-    
+
+    // Schema-constrained (JSON) output is not supported on Windows AI, which is
+    // text-out only. Fail loudly so callers don't expect a constrained result.
+    auto config_it = args.find(EncodableValue("config"));
+    if (config_it != args.end()) {
+      if (const auto* config = std::get_if<EncodableMap>(&config_it->second)) {
+        bool wants_schema =
+            config->find(EncodableValue("schema")) != config->end();
+        auto format_it = config->find(EncodableValue("responseFormat"));
+        const auto* format_ptr = format_it != config->end()
+            ? std::get_if<std::string>(&format_it->second)
+            : nullptr;
+        bool wants_json = format_ptr != nullptr && *format_ptr == "json";
+        if (wants_schema || wants_json) {
+          result->Error(
+              "STRUCTURED_OUTPUT_UNSUPPORTED",
+              "Schema-constrained (JSON) output is not supported on Windows AI.");
+          return;
+        }
+      }
+    }
+
     // Build full prompt with instructions if provided
     std::string fullPrompt = prompt;
     if (!instructions_.empty()) {


### PR DESCRIPTION
 This branch adds schema-constrained JSON generation ("structured outputs") to the plugin, built on the existing FoundationModels DynamicGenerationSchema machinery.  It only supports Apple, other frameworks will through unsupported errors.

Added tests for changes.