### PR TITLE
Harden the structured-output API (Dart side)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 0.0.15
+
+### Structured (JSON-schema) outputs
+
+* **Apple (iOS 26 / macOS 26):** native schema-constrained generation. A JSON
+  Schema passed through `GenerationConfig.schema` is translated into a
+  FoundationModels `GenerationSchema`, so the model is forced to emit matching
+  JSON. Supported constructs: nested objects (with `required`), arrays (with
+  `minItems` / `maxItems`), string enums, and the scalar types. Read the result
+  with `AiResponse.json` (object roots) or `AiResponse.decodedJson` (any root).
+* **Android / Windows:** unchanged — these backends are text-out only and report
+  `supportsStructuredOutput: false`. Passing a `schema` (or
+  `ResponseFormat.json`) throws `STRUCTURED_OUTPUT_UNSUPPORTED`. The ML Kit GenAI
+  on-device Prompt API does not currently expose a `responseSchema` /
+  `responseMimeType`; gate on `getPlatformInfo().supportsStructuredOutput`.
+
+### Hardening of the structured-output API
+
+* A `schema` now implies JSON mode consistently: you no longer have to also set
+  `responseFormat: ResponseFormat.json`, and `GenerationConfig.toMap()` never
+  sends a schema paired with a `text` format (`effectiveResponseFormat` /
+  `requestsStructuredOutput` expose this).
+* Schemas are validated in Dart **before** the platform channel
+  (`GenerationConfig.validateSchema()`), so unsupported constructs fail fast with
+  a path-qualified `ArgumentError` instead of an opaque native error.
+* `AiResponse.decodedJson` decodes a root array or scalar; `AiResponse.json`
+  stays object-only for backwards compatibility.
+* `generateTextStream` now rejects schema-constrained requests up front (no
+  backend can constrain streamed output yet) instead of silently returning
+  free-form text — the returned stream errors immediately. Use `generateText`
+  for structured output.
+
 ## 0.0.14
 
 ### Android: tool calling is explicitly unsupported

--- a/README.md
+++ b/README.md
@@ -484,7 +484,20 @@ emit a value matching your schema.
 
 Supported schema constructs: nested objects (with `required`), arrays (including
 `minItems` / `maxItems`), string enums, and the scalar types (`string`,
-`integer`, `number`, `boolean`). `description` is honored on properties.
+`integer`, `number`, `boolean`). `description` is honored on properties. A schema
+using any construct outside this subset is rejected with an `ArgumentError` in
+Dart — before the platform channel — so you get a clear, path-qualified message
+instead of an opaque native failure.
+
+Supplying a `schema` implies JSON mode: you don't need to also set
+`responseFormat: ResponseFormat.json` (though you can), and the value sent to the
+backend is always self-consistent.
+
+> **Streaming:** schema-constrained output is **not** available through
+> `generateTextStream` on any backend yet (Apple's streaming path can't constrain
+> to a schema, and Android is text-out only). Passing a `schema` to
+> `generateTextStream` returns a stream that errors immediately — use
+> `generateText` for structured output, or stream without a schema.
 
 ```dart
 final platform = await aiEngine.getPlatformInfo();
@@ -515,8 +528,12 @@ final response = await aiEngine.generateText(
   ),
 );
 
-final data = response.json; // Map<String, dynamic>? — decoded JSON
+final data = response.json; // Map<String, dynamic>? — decoded JSON object
 print(data?['title']);
+
+// For a schema whose root is an array or scalar, use decodedJson instead —
+// .json only returns object roots.
+final value = response.decodedJson; // Object? — any decoded JSON value
 ```
 
 > Note: `ResponseFormat.json` requires a non-null `schema` — Apple can only
@@ -869,7 +886,7 @@ Configuration for text generation.
 - `topP` (double?, optional) - Top-p (nucleus) sampling. On Apple maps to `.random(probabilityThreshold:)`
 - `topK` (int?, optional) - Top-k sampling. On Apple maps to `.random(top:)` and takes precedence over `topP`
 - `responseFormat` (`ResponseFormat`, default: `text`) - `text` for free-form output, or `json` for schema-constrained JSON (Apple only). `json` requires a non-null `schema`
-- `schema` (`Map<String, dynamic>?`, optional) - JSON Schema the output is constrained to (Apple only; see Structured Outputs above)
+- `schema` (`Map<String, dynamic>?`, optional) - JSON Schema the output is constrained to (Apple only; see Structured Outputs above). Supplying a schema implies JSON mode and is validated in Dart before the platform channel
 
 > Sampling precedence on Apple: topK > topP > temperature > greedy. `.greedy` is
 > never combined with a temperature (that pairing throws on-device).
@@ -880,6 +897,7 @@ Response from AI generation.
 
 - `text` (String) - The generated text (or the JSON string when structured output was requested)
 - `json` (`Map<String, dynamic>?`) - `text` decoded as a JSON object, or `null` if it isn't one
+- `decodedJson` (`Object?`) - `text` decoded as any JSON value (object, array, scalar), or `null` if it isn't valid JSON — use for schemas whose root is an array or scalar
 - `tokenCount` (int?) - Token count used
 - `generationTimeMs` (int?) - Generation time in milliseconds
 

--- a/lib/src/flutter_local_ai.dart
+++ b/lib/src/flutter_local_ai.dart
@@ -60,16 +60,35 @@ class FlutterLocalAi {
   /// Emits delta chunks (only the newly generated text) and closes when the
   /// generation completes. Backends without a streaming implementation surface
   /// an error on the stream instead — callers can fall back to [generateText].
+  ///
+  /// Streaming with a [GenerationConfig.schema] (or [ResponseFormat.json]) is
+  /// not supported on any backend yet — Apple's streaming path can't constrain
+  /// output to a schema and Android is text-out only — so such a request yields
+  /// a stream that errors immediately. Use [generateText] for schema-constrained
+  /// output, or stream without a schema.
   Stream<String> generateTextStream({
     required String prompt,
     GenerationConfig? config,
     String? instructions,
-  }) =>
-      FlutterLocalAiPlatform.instance.generateTextStream(
-        prompt: prompt,
-        config: config,
-        instructions: instructions,
+  }) {
+    if (config?.requestsStructuredOutput ?? false) {
+      return Stream<String>.error(
+        ArgumentError.value(
+          config,
+          'config',
+          'Streaming structured (JSON/schema) output is not supported on any '
+              'backend yet. Use generateText() for schema-constrained output, '
+              'or call generateTextStream() without a schema / '
+              'ResponseFormat.json.',
+        ),
       );
+    }
+    return FlutterLocalAiPlatform.instance.generateTextStream(
+      prompt: prompt,
+      config: config,
+      instructions: instructions,
+    );
+  }
 
   /// Generate text with a simple prompt (convenience method)
   ///

--- a/lib/src/flutter_local_ai_method_channel.dart
+++ b/lib/src/flutter_local_ai_method_channel.dart
@@ -142,6 +142,10 @@ class MethodChannelFlutterLocalAi extends FlutterLocalAiPlatform {
     GenerationConfig? config,
     String? instructions,
   }) async {
+    // Catch unsupported schema constructs in Dart so callers get a clear
+    // ArgumentError here rather than an opaque native failure after the round
+    // trip.
+    config?.validateSchema();
     try {
       final arguments = {
         'prompt': prompt,

--- a/lib/src/models/ai_response.dart
+++ b/lib/src/models/ai_response.dart
@@ -18,13 +18,26 @@ class AiResponse {
   });
 
   /// The generated text decoded as a JSON object, or `null` if [text] is not a
-  /// JSON object (e.g. free-form text, or malformed/truncated JSON). Use this
-  /// when generation was constrained by a schema via
-  /// `GenerationConfig(responseFormat: ResponseFormat.json, schema: ...)`.
+  /// JSON object (e.g. free-form text, a root array/scalar, or malformed JSON).
+  /// Use this when generation was constrained by an object schema via
+  /// `GenerationConfig(responseFormat: ResponseFormat.json, schema: ...)`. For
+  /// schemas whose root is an array or scalar, use [decodedJson].
   Map<String, dynamic>? get json {
+    final decoded = decodedJson;
+    return decoded is Map<String, dynamic> ? decoded : null;
+  }
+
+  /// The generated [text] decoded as any JSON value — object, array, string,
+  /// number, boolean, or `null` — or `null` if [text] isn't valid JSON. Use
+  /// this when a schema's root is an array or scalar; for object roots, [json]
+  /// is the typed `Map` convenience view.
+  ///
+  /// Note: a `null` result is ambiguous between "not valid JSON" and the JSON
+  /// literal `null`. Schema-constrained output is rarely a bare null, but check
+  /// [text] directly if you must distinguish the two.
+  Object? get decodedJson {
     try {
-      final decoded = jsonDecode(text);
-      return decoded is Map<String, dynamic> ? decoded : null;
+      return jsonDecode(text);
     } on FormatException {
       return null;
     }

--- a/lib/src/models/generation_config.dart
+++ b/lib/src/models/generation_config.dart
@@ -1,3 +1,5 @@
+import 'schema_validation.dart';
+
 /// Desired shape of the generated output.
 enum ResponseFormat {
   /// Free-form text (the default).
@@ -26,7 +28,8 @@ class GenerationConfig {
   final int? topK;
 
   /// Desired output format. Defaults to [ResponseFormat.text]. Selecting
-  /// [ResponseFormat.json] requires a non-null [schema].
+  /// [ResponseFormat.json] requires a non-null [schema]. Supplying a [schema]
+  /// implies JSON mode regardless of this field — see [effectiveResponseFormat].
   final ResponseFormat responseFormat;
 
   /// JSON Schema describing the structured output. When provided (with
@@ -47,13 +50,35 @@ class GenerationConfig {
           'ResponseFormat.json requires a non-null schema.',
         );
 
+  /// Whether this config asks for schema-constrained JSON output. True when a
+  /// [schema] is supplied (which implies JSON mode) or [responseFormat] is
+  /// [ResponseFormat.json]. Backends that report `supportsStructuredOutput:
+  /// false` reject such requests.
+  bool get requestsStructuredOutput =>
+      schema != null || responseFormat == ResponseFormat.json;
+
+  /// The format actually sent to the backend: supplying a [schema] implies
+  /// [ResponseFormat.json], so the wire format never disagrees with the
+  /// presence of a schema (Apple keys structured output off the schema alone).
+  ResponseFormat get effectiveResponseFormat =>
+      schema != null ? ResponseFormat.json : responseFormat;
+
+  /// Validates [schema] against the JSON Schema subset the native backends can
+  /// translate, throwing an [ArgumentError] if it uses unsupported constructs.
+  /// A no-op when no schema is set. Call ahead of generation to fail fast in
+  /// Dart instead of with an opaque native error.
+  void validateSchema() {
+    final schema = this.schema;
+    if (schema != null) validateGenerationSchema(schema);
+  }
+
   Map<String, dynamic> toMap() {
     return {
       'maxTokens': maxTokens,
       if (temperature != null) 'temperature': temperature,
       if (topP != null) 'topP': topP,
       if (topK != null) 'topK': topK,
-      'responseFormat': responseFormat.name,
+      'responseFormat': effectiveResponseFormat.name,
       if (schema != null) 'schema': schema,
     };
   }

--- a/lib/src/models/schema_validation.dart
+++ b/lib/src/models/schema_validation.dart
@@ -1,0 +1,100 @@
+/// The scalar JSON Schema types the native backends can translate.
+const _scalarTypes = {'string', 'integer', 'number', 'boolean'};
+
+/// Validates that [schema] uses only the JSON Schema subset the native backends
+/// can translate (Apple FoundationModels `GenerationSchema`), throwing an
+/// [ArgumentError] with a path-qualified message otherwise. Catching invalid
+/// schemas in Dart yields a clear, immediate error instead of an opaque native
+/// failure after the method-channel round trip.
+///
+/// Supported constructs (mirrors the Apple `SchemaBuilder`):
+/// - objects: `type: 'object'` (or omitted) with `properties` (each itself a
+///   schema), an optional `required` list of property names, and `description`;
+/// - arrays: `type: 'array'` with an `items` schema and optional integer
+///   `minItems` / `maxItems`;
+/// - string enums: `enum` as a non-empty list of strings (with or without a
+///   `type`);
+/// - scalars: a `type` of `string`, `integer`, `number`, or `boolean`.
+void validateGenerationSchema(Map<String, dynamic> schema) {
+  _validateNode(schema, r'$');
+}
+
+void _validateNode(Object? node, String path) {
+  if (node is! Map) {
+    throw ArgumentError.value(
+        node, 'schema', 'Schema node at $path must be a map.');
+  }
+
+  // An `enum` is a string-choice constraint regardless of any `type`, matching
+  // the native builder which short-circuits on it.
+  if (node.containsKey('enum')) {
+    final choices = node['enum'];
+    if (choices is! List || choices.isEmpty) {
+      throw ArgumentError.value(choices, 'enum',
+          'Schema `enum` at $path must be a non-empty list of strings.');
+    }
+    for (var i = 0; i < choices.length; i++) {
+      if (choices[i] is! String) {
+        throw ArgumentError.value(choices[i], 'enum',
+            'Schema `enum` at $path[$i] must be a string; only string enums '
+            'are supported.');
+      }
+    }
+    return;
+  }
+
+  final rawType = node['type'];
+  if (rawType != null && rawType is! String) {
+    // e.g. `type: ['string', 'null']` for nullability — not supported yet.
+    throw ArgumentError.value(rawType, 'type',
+        'Schema `type` at $path must be a string; union/nullable types are '
+        'not supported.');
+  }
+  final type = (rawType as String?)?.toLowerCase() ?? 'object';
+
+  switch (type) {
+    case 'object':
+      final properties = node['properties'];
+      if (properties != null) {
+        if (properties is! Map) {
+          throw ArgumentError.value(properties, 'properties',
+              'Schema `properties` at $path must be a map.');
+        }
+        properties.forEach((key, value) {
+          _validateNode(value, '$path.properties.$key');
+        });
+      }
+      final required = node['required'];
+      if (required != null &&
+          (required is! List || required.any((e) => e is! String))) {
+        throw ArgumentError.value(required, 'required',
+            'Schema `required` at $path must be a list of property-name '
+            'strings.');
+      }
+      return;
+
+    case 'array':
+      final items = node['items'];
+      if (items == null) {
+        throw ArgumentError.value(null, 'items',
+            'Array schema at $path requires an `items` schema.');
+      }
+      _validateNode(items, '$path.items');
+      _validateIntBound(node['minItems'], 'minItems', path);
+      _validateIntBound(node['maxItems'], 'maxItems', path);
+      return;
+
+    default:
+      if (_scalarTypes.contains(type)) return;
+      throw ArgumentError.value(type, 'type',
+          'Unsupported schema type `$type` at $path. Supported: object, '
+          'array, string, integer, number, boolean, or a string `enum`.');
+  }
+}
+
+void _validateIntBound(Object? value, String key, String path) {
+  if (value != null && value is! int) {
+    throw ArgumentError.value(
+        value, key, 'Schema `$key` at $path must be an integer.');
+  }
+}

--- a/test/flutter_local_ai_test.dart
+++ b/test/flutter_local_ai_test.dart
@@ -149,6 +149,20 @@ void main() {
       // The JSON arrives in `text`; `.json` is the decoded convenience view.
       expect(result.json, {'title': 'Hello', 'priority': 'high'});
     });
+
+    test('generateTextStream rejects structured-output requests', () async {
+      final config = GenerationConfig(
+        responseFormat: ResponseFormat.json,
+        schema: const {'type': 'object'},
+      );
+
+      await expectLater(
+        subject.generateTextStream(prompt: 'Hi', config: config),
+        emitsError(isA<ArgumentError>()),
+      );
+      // The request never reached the platform.
+      expect(fakePlatform.lastPrompt, isNull);
+    });
   });
 
   group('GenerationConfig', () {
@@ -181,11 +195,49 @@ void main() {
       });
     });
 
+    test('a schema implies JSON mode even when responseFormat is left text', () {
+      const config = GenerationConfig(
+        maxTokens: 100,
+        schema: {'type': 'object'},
+      );
+
+      // The field still reflects what the caller passed...
+      expect(config.responseFormat, ResponseFormat.text);
+      // ...but the effective/wire format is promoted to json so the backend
+      // never sees a schema paired with a 'text' format.
+      expect(config.effectiveResponseFormat, ResponseFormat.json);
+      expect(config.requestsStructuredOutput, isTrue);
+      expect(config.toMap()['responseFormat'], 'json');
+    });
+
+    test('requestsStructuredOutput is false for plain text generation', () {
+      const config = GenerationConfig(maxTokens: 100);
+      expect(config.requestsStructuredOutput, isFalse);
+      expect(config.effectiveResponseFormat, ResponseFormat.text);
+    });
+
     test('JSON response format requires a schema', () {
       expect(
         () => GenerationConfig(responseFormat: ResponseFormat.json),
         throwsA(isA<AssertionError>()),
       );
+    });
+
+    test('validateSchema is a no-op without a schema', () {
+      const config = GenerationConfig(maxTokens: 100);
+      expect(config.validateSchema, returnsNormally);
+    });
+
+    test('validateSchema rejects an unsupported schema construct', () {
+      const config = GenerationConfig(
+        schema: {
+          'type': 'object',
+          'properties': {
+            'when': {'type': 'date'}, // unsupported scalar
+          },
+        },
+      );
+      expect(config.validateSchema, throwsArgumentError);
     });
   });
 
@@ -203,6 +255,29 @@ void main() {
     test('returns null for non-object JSON (e.g. an array)', () {
       const response = AiResponse(text: '[1, 2, 3]');
       expect(response.json, isNull);
+    });
+  });
+
+  group('AiResponse.decodedJson', () {
+    test('decodes a root object', () {
+      const response = AiResponse(text: '{"a":1}');
+      expect(response.decodedJson, {'a': 1});
+    });
+
+    test('decodes a root array (where .json returns null)', () {
+      const response = AiResponse(text: '[1, 2, 3]');
+      expect(response.json, isNull);
+      expect(response.decodedJson, [1, 2, 3]);
+    });
+
+    test('decodes a root scalar', () {
+      const response = AiResponse(text: '42');
+      expect(response.decodedJson, 42);
+    });
+
+    test('returns null for free-form text', () {
+      const response = AiResponse(text: 'just words');
+      expect(response.decodedJson, isNull);
     });
   });
 

--- a/test/schema_validation_test.dart
+++ b/test/schema_validation_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_local_ai/src/models/schema_validation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('validateGenerationSchema (supported subset)', () {
+    test('accepts a nested object with properties, required, and description',
+        () {
+      expect(
+        () => validateGenerationSchema(const {
+          'type': 'object',
+          'description': 'A support ticket',
+          'properties': {
+            'title': {'type': 'string', 'description': 'Short headline'},
+            'priority': {
+              'enum': ['low', 'med', 'high'],
+            },
+            'tags': {
+              'type': 'array',
+              'items': {'type': 'string'},
+              'minItems': 1,
+              'maxItems': 5,
+            },
+            'meta': {
+              'type': 'object',
+              'properties': {
+                'count': {'type': 'integer'},
+                'ratio': {'type': 'number'},
+                'urgent': {'type': 'boolean'},
+              },
+            },
+          },
+          'required': ['title'],
+        }),
+        returnsNormally,
+      );
+    });
+
+    test('treats an object as the default when type is omitted', () {
+      expect(() => validateGenerationSchema(const {}), returnsNormally);
+      expect(
+        () => validateGenerationSchema(const {
+          'properties': {
+            'a': {'type': 'string'},
+          },
+        }),
+        returnsNormally,
+      );
+    });
+
+    test('accepts an enum with or without an explicit type', () {
+      expect(
+        () => validateGenerationSchema(const {
+          'enum': ['a', 'b'],
+        }),
+        returnsNormally,
+      );
+      expect(
+        () => validateGenerationSchema(const {
+          'type': 'string',
+          'enum': ['a', 'b'],
+        }),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('validateGenerationSchema (rejections)', () {
+    test('rejects an empty enum', () {
+      expect(
+        () => validateGenerationSchema(const {'enum': []}),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects a non-string enum value', () {
+      expect(
+        () => validateGenerationSchema(const {
+          'enum': ['a', 1],
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects an unsupported scalar type', () {
+      expect(
+        () => validateGenerationSchema(const {'type': 'date'}),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects a union/nullable type list', () {
+      expect(
+        () => validateGenerationSchema(const {
+          'type': ['string', 'null'],
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects an array without items', () {
+      expect(
+        () => validateGenerationSchema(const {'type': 'array'}),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects non-integer array bounds', () {
+      expect(
+        () => validateGenerationSchema(const {
+          'type': 'array',
+          'items': {'type': 'string'},
+          'minItems': 1.5,
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects a property whose schema is not a map', () {
+      expect(
+        () => validateGenerationSchema(const {
+          'type': 'object',
+          'properties': {'title': 'string'},
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects a non-string required entry', () {
+      expect(
+        () => validateGenerationSchema(const {
+          'type': 'object',
+          'properties': {
+            'title': {'type': 'string'},
+          },
+          'required': [1],
+        }),
+        throwsArgumentError,
+      );
+    });
+
+    test('surfaces the offending path in nested schemas', () {
+      expect(
+        () => validateGenerationSchema(const {
+          'type': 'object',
+          'properties': {
+            'items': {
+              'type': 'array',
+              'items': {'type': 'date'},
+            },
+          },
+        }),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains(r'$.properties.items.items'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Make schema usage consistent and fail-fast, and surface non-object JSON roots, ahead of native (Apple) schema-translation work:

- GenerationConfig: a schema implies JSON mode (effectiveResponseFormat / requestsStructuredOutput); toMap never sends a schema paired with a 'text' format.
- Validate schemas in Dart before the platform channel (validateSchema / validateGenerationSchema) against the subset the Apple SchemaBuilder supports, throwing a path-qualified ArgumentError instead of an opaque native error.
- AiResponse.decodedJson decodes root arrays/scalars; json stays object-only for compatibility.
- generateTextStream rejects schema requests up front (no backend can constrain streamed output yet) instead of silently returning free-form text.

Adds unit coverage (49 passing) and updates README + CHANGELOG (0.0.15). Apple SchemaBuilder expansion and Android native support remain follow-ups.